### PR TITLE
Feature/#4 crypto price with span

### DIFF
--- a/src/AuthorizedBuyersHelpers/ABCrypto.cs
+++ b/src/AuthorizedBuyersHelpers/ABCrypto.cs
@@ -81,7 +81,7 @@ namespace AuthorizedBuyersHelpers {
         /// <paramref name="plainBytes"/> の長さが <see cref="MaxPayloadSize"/> を超えています。
         /// または、<paramref name="cipherBytes"/> の長さが <paramref name="plainBytes"/> の長さと <see cref="OverheadSize"/> を加算した値を満たしません。
         /// </exception>
-        public void Encrypt(in ReadOnlySpan<byte> plainBytes, in ReadOnlySpan<byte> inputIV, in Span<byte> cipherBytes, out int bytesWritten) {
+        public void Encrypt(ReadOnlySpan<byte> plainBytes, ReadOnlySpan<byte> inputIV, Span<byte> cipherBytes, out int bytesWritten) {
             if (plainBytes.Length > MaxPayloadSize) { throw new ArgumentOutOfRangeException($"{nameof(plainBytes)} の長さが {plainBytes.Length} です。これは最大長 {MaxPayloadSize} を超えています。", nameof(plainBytes)); }
             if (cipherBytes.Length < plainBytes.Length + OverheadSize) { throw new ArgumentOutOfRangeException($"{nameof(cipherBytes)} の長さは {cipherBytes.Length} ですが、少なくとも {plainBytes.Length + OverheadSize} 必要です。", nameof(cipherBytes)); }
 
@@ -110,7 +110,7 @@ namespace AuthorizedBuyersHelpers {
         /// <paramref name="plainBytes"/> の長さが <see cref="MaxPayloadSize"/> を超えているか、
         /// <paramref name="cipherBytes"/> の長さが <paramref name="plainBytes"/> の長さと <see cref="OverheadSize"/> を加算した値を満たしていない場合は <c>false</c>。
         /// </returns>
-        public bool TryEncrypt(in ReadOnlySpan<byte> plainBytes, in ReadOnlySpan<byte> inputIV, in Span<byte> cipherBytes, out int bytesWritten) {
+        public bool TryEncrypt(ReadOnlySpan<byte> plainBytes, ReadOnlySpan<byte> inputIV, Span<byte> cipherBytes, out int bytesWritten) {
             if (plainBytes.Length > MaxPayloadSize) { goto Failure; }
             if (cipherBytes.Length < plainBytes.Length + OverheadSize) { goto Failure; }
 
@@ -157,7 +157,7 @@ Failure:
         ///     <term>復号化された平文から作成した署名が、<paramref name="cipherBytes"/> に含まれる署名と一致しない。</term>
         /// </list>
         /// </returns>
-        public bool TryDecrypt(in ReadOnlySpan<byte> cipherBytes, in Span<byte> plainBytes, out int bytesWritten) {
+        public bool TryDecrypt(ReadOnlySpan<byte> cipherBytes, Span<byte> plainBytes, out int bytesWritten) {
             var payloadSize = cipherBytes.Length - OverheadSize;
             if (payloadSize < 0) { goto Failure; }
             if (payloadSize > MaxPayloadSize) { goto Failure; }
@@ -186,7 +186,7 @@ Failure:
         /// </summary>
         /// <param name="iv">暗号化に使用される初期化ベクトル。</param>
         /// <param name="payload">XOR 暗号を適用するペイロード。</param>
-        private void XorPayload(in ReadOnlySpan<byte> iv, in Span<byte> payload) {
+        private void XorPayload(ReadOnlySpan<byte> iv, Span<byte> payload) {
             Debug.Assert(iv.Length == IVSize);
             Debug.Assert(payload.Length <= MaxPayloadSize);
 
@@ -230,7 +230,7 @@ Failure:
         /// <param name="iv">署名に使用される初期化ベクトル。</param>
         /// <param name="playinBytes">署名対象の平文。</param>
         /// <param name="destination">書名の書き込み先となる <see cref="byte"/> スパン。</param>
-        private void ComputeSignature(in ReadOnlySpan<byte> iv, in ReadOnlySpan<byte> playinBytes, in Span<byte> destination) {
+        private void ComputeSignature(ReadOnlySpan<byte> iv, ReadOnlySpan<byte> playinBytes, Span<byte> destination) {
             Debug.Assert(iv.Length == IVSize);
             Debug.Assert(playinBytes.Length <= MaxPayloadSize);
             Debug.Assert(destination.Length == SignatureSize);

--- a/src/AuthorizedBuyersHelpers/ABIV.cs
+++ b/src/AuthorizedBuyersHelpers/ABIV.cs
@@ -26,7 +26,7 @@ namespace AuthorizedBuyersHelpers {
         /// 成功した場合は常に <see cref="ABCrypto.IVSize"/> になります。
         /// </param>
         /// <returns>生成に成功した場合は <c>true</c>、失敗した場合は <c>false</c> となります。</returns>
-        public static bool TryCreate(in Span<byte> destination, out int bytesWritten) {
+        public static bool TryCreate(Span<byte> destination, out int bytesWritten) {
             var rnd = _random.Value;
             var serverId = (long)rnd.Next() << 32 | (long)rnd.Next();
             return TryCreate(DateTime.UtcNow, serverId, destination, out bytesWritten);
@@ -47,7 +47,7 @@ namespace AuthorizedBuyersHelpers {
         /// <paramref name="destination"/> の長さが <see cref="ABCrypto.IVSize"/> に満たない場合、
         /// または <paramref name="date"/> が <see cref="UnixTime.Epoch"/> より古い日時の場合、<c>false</c> となります。
         /// </returns>
-        public static bool TryCreate(DateTime date, long serverId, in Span<byte> destination, out int bytesWritten) {
+        public static bool TryCreate(DateTime date, long serverId, Span<byte> destination, out int bytesWritten) {
             if (destination.Length < ABCrypto.IVSize) {
                 bytesWritten = 0;
                 return false;

--- a/src/AuthorizedBuyersHelpers/ABPriceCrypto.cs
+++ b/src/AuthorizedBuyersHelpers/ABPriceCrypto.cs
@@ -11,7 +11,13 @@ namespace AuthorizedBuyersHelpers {
     /// <remarks>
     /// https://developers.google.com/authorized-buyers/rtb/response-guide/decrypt-price
     /// </remarks>
-    public static class ABCryptoPriceExtensions {
+    public static class ABPriceCrypto {
+
+        /// <summary>
+        /// 暗号化された価格のバイトサイズ。
+        /// </summary>
+        public const int CipherSize = ABCrypto.OverheadSize + PricePayloadSize;
+
         private const int PricePayloadSize = 8;
         private const int MicrosPerCurrencyUnit = 1_000_000;
 
@@ -50,12 +56,9 @@ namespace AuthorizedBuyersHelpers {
         public static string EncryptPrice(this ABCrypto crypto, decimal price, ReadOnlySpan<byte> inputIV) {
             if (crypto == null) { throw new ArgumentNullException(nameof(crypto)); }
 
-            Span<byte> microPriceData = stackalloc byte[PricePayloadSize];
-            BinaryPrimitives.WriteInt64BigEndian(microPriceData, (long)(price * MicrosPerCurrencyUnit));
-
-            var cipherBytes = ArrayPool<byte>.Shared.RentAsSegment(ABCrypto.OverheadSize + PricePayloadSize);
+            var cipherBytes = ArrayPool<byte>.Shared.RentAsSegment(CipherSize);
             try {
-                var success = crypto.TryEncrypt(microPriceData, inputIV, cipherBytes, out _);
+                var success = TryEncryptPrice(crypto, price, inputIV, cipherBytes, out _);
                 Debug.Assert(success);
 
                 return ABCipherEncoder.Encode(cipherBytes);
@@ -66,7 +69,50 @@ namespace AuthorizedBuyersHelpers {
         }
 
         /// <summary>
-        /// <see cref="ABCrypto"/> で暗号化された暗号文を価格に復号化します。
+        /// 価格を暗号化します。
+        /// </summary>
+        /// <param name="crypto">暗号化オブジェクト。</param>
+        /// <param name="price">暗号化対象の価格。</param>
+        /// <param name="inputIV">
+        /// 暗号化に使用される初期化ベクトル。
+        /// 長さが <see cref="ABCrypto.IVSize"/> に満たない場合は不足分を 0 で埋め、<see cref="ABCrypto.IVSize"/> を超える場合は <see cref="ABCrypto.IVSize"/> まで切り詰めて使用します。
+        /// </param>
+        /// <param name="cipherBytes">
+        /// 暗号データの書き込み先となる <see cref="byte"/> スパン。
+        /// 少なくとも <see cref="CipherSize"/> 以上の長さが必要です。
+        /// </param>
+        /// <param name="bytesWritten">
+        /// 実際に <paramref name="cipherBytes"/> に書き込まれたバイトサイズ。
+        /// 暗号化に成功した場合は <see cref="CipherSize"/> の値になります。
+        /// </param>
+        /// <returns>
+        /// 暗号化に成功した場合は <c>true</c>。
+        /// <paramref name="cipherBytes"/> の長さが <see cref="CipherSize"/> を満たしていない場合は <c>false</c>。
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="crypto"/> is <c>null</c>.</exception>
+        /// <exception cref="OverflowException">
+        /// <paramref name="price"/> が <c><see cref="long.MaxValue"/> / 1_000_000</c> より大きい、
+        /// または <c><see cref="long.MinValue"/> / 1_000_000 より小さい。</c>
+        /// </exception>
+        public static bool TryEncryptPrice(this ABCrypto crypto, decimal price, ReadOnlySpan<byte> inputIV, Span<byte> cipherBytes, out int bytesWritten) {
+            if (crypto == null) { throw new ArgumentNullException(nameof(crypto)); }
+            if (cipherBytes.Length < CipherSize) { goto Failure; }
+
+            Span<byte> microPriceData = stackalloc byte[PricePayloadSize];
+            BinaryPrimitives.WriteInt64BigEndian(microPriceData, (long)(price * MicrosPerCurrencyUnit));
+
+            var success = crypto.TryEncrypt(microPriceData, inputIV, cipherBytes, out bytesWritten);
+            Debug.Assert(success);
+            Debug.Assert(bytesWritten == CipherSize);
+            return true;
+
+Failure:
+            bytesWritten = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// <see cref="ABCrypto"/> によって暗号化された暗号文を価格に復号化します。
         /// </summary>
         /// <param name="crypto">暗号化オブジェクト。</param>
         /// <param name="cipherPrice">暗号化された価格を表す暗号文。</param>
@@ -77,7 +123,25 @@ namespace AuthorizedBuyersHelpers {
             if (crypto == null) { throw new ArgumentNullException(nameof(crypto)); }
 
             if (!ABCipherEncoder.TryDecode(cipherPrice, out var cipherBytes)) { goto Failure; }
-            if (cipherBytes.Length != ABCrypto.OverheadSize + PricePayloadSize) { goto Failure; }
+
+            return TryDecryptPrice(crypto, cipherBytes, out price);
+
+Failure:
+            price = default;
+            return false;
+        }
+
+        /// <summary>
+        /// <see cref="ABCrypto"/> によって暗号化された価格を復号化します。
+        /// </summary>
+        /// <param name="crypto">暗号化オブジェクト。</param>
+        /// <param name="cipherBytes">暗号化された価格を表す暗号データ。</param>
+        /// <param name="price">復号化された価格。</param>
+        /// <returns>復号化に成功した場合は <c>true</c>、それ以外なら <c>false</c>。</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="crypto"/> is <c>null</c>.</exception>
+        public static bool TryDecryptPrice(this ABCrypto crypto, ReadOnlySpan<byte> cipherBytes, out decimal price) {
+            if (crypto == null) { throw new ArgumentNullException(nameof(crypto)); }
+            if (cipherBytes.Length != CipherSize) { goto Failure; }
 
             Span<byte> microPriceData = stackalloc byte[PricePayloadSize];
             if (!crypto.TryDecrypt(cipherBytes, microPriceData, out _)) { goto Failure; }

--- a/tests/AuthorizedBuyersHelpers.Tests/ABPriceCryptoTests.cs
+++ b/tests/AuthorizedBuyersHelpers.Tests/ABPriceCryptoTests.cs
@@ -5,14 +5,14 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace AuthorizedBuyersHelpers.Tests {
 
     [TestClass]
-    public class ABCryptoPriceExtensionsTests {
+    public class ABPriceCryptoTests {
 
         [TestMethod]
         public void EncryptPrice_AutoIV() {
             Action TestCase(int testNumber, ABCrypto crypto, decimal price, Type expectedExceptionType = null) => () => {
                 new TestCaseRunner($"No.{testNumber}")
                     .Run(() => {
-                        var cipher = ABCryptoPriceExtensions.EncryptPrice(crypto, price);
+                        var cipher = ABPriceCrypto.EncryptPrice(crypto, price);
                         Console.WriteLine(cipher);
                         return (success: crypto.TryDecryptPrice(cipher, out var actualPrice), price: actualPrice);
                     })
@@ -41,7 +41,7 @@ namespace AuthorizedBuyersHelpers.Tests {
         public void EncryptPrice() {
             Action TestCase(int testNumber, ABCrypto crypto, decimal price, byte[] inputIV, string expected, Type expectedExceptionType = null) => () => {
                 new TestCaseRunner($"No.{testNumber}")
-                    .Run(() => ABCryptoPriceExtensions.EncryptPrice(crypto, price, inputIV))
+                    .Run(() => ABPriceCrypto.EncryptPrice(crypto, price, inputIV))
                     .Verify(expected, expectedExceptionType);
             };
 
@@ -65,10 +65,15 @@ namespace AuthorizedBuyersHelpers.Tests {
         }
 
         [TestMethod]
+        public void TryEncryptPrice_ReadOnlySpan() {
+            Assert.Inconclusive();
+        }
+
+        [TestMethod]
         public void TryDecryptPrice() {
             Action TestCase(int testNumber, ABCrypto crypto, string cipherPrice, (bool, decimal) expected, Type expectedExceptionType = null) => () => {
                 new TestCaseRunner($"No.{testNumber}")
-                    .Run(() => (ABCryptoPriceExtensions.TryDecryptPrice(crypto, cipherPrice, out var price), price))
+                    .Run(() => (ABPriceCrypto.TryDecryptPrice(crypto, cipherPrice, out var price), price))
                     .Verify(expected, expectedExceptionType);
             };
 
@@ -83,6 +88,11 @@ namespace AuthorizedBuyersHelpers.Tests {
                 TestCase( 7, _crypto, "5nmwvgAM0UABI0VniavN72_sy3T6V9oglpvOpA==", (false, 0)),  // ペイロード改竄。
                 TestCase( 8, _crypto, "OG46wAAMCggBI0VniavN7-mNy0VUYQvRuIJiRw==", (true , 123.45m)),
             }.Run();
+        }
+
+        [TestMethod]
+        public void TryDecryptPrice_Span() {
+            Assert.Inconclusive();
         }
 
         #region Helpers

--- a/tests/AuthorizedBuyersHelpers.Tests/ABPriceCryptoTests.cs
+++ b/tests/AuthorizedBuyersHelpers.Tests/ABPriceCryptoTests.cs
@@ -66,7 +66,34 @@ namespace AuthorizedBuyersHelpers.Tests {
 
         [TestMethod]
         public void TryEncryptPrice_ReadOnlySpan() {
-            Assert.Inconclusive();
+            Action TestCase(int testNumber, ABCrypto crypto, decimal price, byte[] inputIV, byte[] cipherBytes, (bool success, int bytesWritten, byte[] cipherBytes) expected, Type expectedExceptionType = null) => () => {
+                new TestCaseRunner($"No.{testNumber}")
+                    .Run(() => (success: ABPriceCrypto.TryEncryptPrice(crypto, price, inputIV, cipherBytes, out var bytesWritten), cipherBytes, bytesWritten))
+                    .Verify((actual, desc) => {
+                        actual.success.Is(expected.success, desc);
+                        actual.bytesWritten.Is(expected.bytesWritten, desc);
+                        actual.cipherBytes.Is(expected.cipherBytes, desc);
+                    }, expectedExceptionType);
+            };
+
+            var iv = Base16.Decode("386E3AC0000C0A080123456789ABCDEF");
+            var shortIV = Base16.Decode("386E3AC0000C0A080123456789ABCD");
+            var longIV = Base16.Decode("386E3AC0000C0A080123456789ABCDEF01");
+            new[] {
+                TestCase( 0, null   , 0m     , iv     , new byte[28], default, typeof(ArgumentNullException)),
+                TestCase( 1, _crypto, 0m     , iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTOrlB8A3F8A=="))),
+                TestCase( 2, _crypto, -1.2m  , iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7xZyNLqs1wnBKd_m9w=="))),
+                TestCase( 3, _crypto, 0.123m , iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTO1k5XIpbSg=="))),
+                TestCase( 4, _crypto, 1.2m   , iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTKPbB3o5CMQ=="))),
+                TestCase( 5, _crypto, 123.45m, iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VUYQvRuIJiRw=="))),
+                TestCase( 6, _crypto, 123.45m, shortIV, new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavNAF7WOkwZcM1moYKxlA=="))),
+                TestCase( 7, _crypto, 123.45m, longIV , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VUYQvRuIJiRw=="))),
+                TestCase( 8, _crypto, 1.2m   , iv     , new byte[27], (false, 0, new byte[27])),
+                TestCase(10, _crypto, (decimal)long.MinValue / 1_000_000            , iv, new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN72mNy0VTOrlBMgsdYg=="))),
+                TestCase(11, _crypto, (decimal)long.MinValue / 1_000_000 - 0.000001m, iv, new byte[28], default, typeof(OverflowException)),
+                TestCase(12, _crypto, (decimal)long.MaxValue / 1_000_000            , iv, new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN75ZyNLqsxUa-p2RaNA=="))),
+                TestCase(13, _crypto, (decimal)long.MaxValue / 1_000_000 + 1        , iv, new byte[28], default, typeof(OverflowException)),
+            }.Run();
         }
 
         [TestMethod]
@@ -92,7 +119,22 @@ namespace AuthorizedBuyersHelpers.Tests {
 
         [TestMethod]
         public void TryDecryptPrice_Span() {
-            Assert.Inconclusive();
+            Action TestCase(int testNumber, ABCrypto crypto, byte[] cipherBytes, (bool, decimal) expected, Type expectedExceptionType = null) => () => {
+                new TestCaseRunner($"No.{testNumber}")
+                    .Run(() => (ABPriceCrypto.TryDecryptPrice(crypto, cipherBytes, out var price), price))
+                    .Verify(expected, expectedExceptionType);
+            };
+
+            new[] {
+                TestCase( 0, null   , default                                                     , default, typeof(ArgumentNullException)),
+                TestCase( 1, _crypto, null                                                        , (false, 0)),
+                TestCase( 2, _crypto, new byte[0]                                                 , (false, 0)),
+                TestCase( 3, _crypto, new byte[28]                                                , (false, 0)),
+                TestCase( 5, _crypto, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTKPbB3o5CMQ=="), (true , 1.2m)),
+                TestCase( 6, _crypto, Base64Url.Decode("5nmwvgAM0UABI0VniavN72_sy3T6V9ohlpvOpA=="), (true , 1.2m)),
+                TestCase( 7, _crypto, Base64Url.Decode("5nmwvgAM0UABI0VniavN72_sy3T6V9oglpvOpA=="), (false, 0)),  // ペイロード改竄。
+                TestCase( 8, _crypto, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VUYQvRuIJiRw=="), (true , 123.45m)),
+            }.Run();
         }
 
         #region Helpers


### PR DESCRIPTION
Resolve #4

Changes:
- ABCryptoPriceExtensions を ABPriceCrypto にリネーム。
- 暗号プライスとして Span<byte> を授受する API を ABPriceCrypto に追加。
- 追加 API のテストを作成。
- Span<T> 系パラメーターに付与していた `in` パラメーター修飾子を除去。