### PR TITLE
Release/v2.0.0 alpha.1

### DIFF
--- a/src/AuthorizedBuyersHelpers/ABIV.cs
+++ b/src/AuthorizedBuyersHelpers/ABIV.cs
@@ -21,15 +21,14 @@ namespace AuthorizedBuyersHelpers {
         /// 初期化ベクトルを生成します。
         /// </summary>
         /// <param name="destination">初期化ベクトルの書き込み先となる <see cref="byte"/> のスパン。</param>
-        /// <param name="bytesWritten">
-        /// 実際に <paramref name="destination"/> に書き込まれたバイトサイズ。
-        /// 成功した場合は常に <see cref="ABCrypto.IVSize"/> になります。
-        /// </param>
-        /// <returns>生成に成功した場合は <c>true</c>、失敗した場合は <c>false</c> となります。</returns>
-        public static bool TryCreate(Span<byte> destination, out int bytesWritten) {
+        /// <returns>
+        /// 生成に成功した場合は <c>true</c>。
+        /// <paramref name="destination"/> の長さが <see cref="ABCrypto.IVSize"/> に満たない場合は <c>false</c>。
+        /// </returns>
+        public static bool TryCreate(Span<byte> destination) {
             var rnd = _random.Value;
             var serverId = (long)rnd.Next() << 32 | (long)rnd.Next();
-            return TryCreate(DateTime.UtcNow, serverId, destination, out bytesWritten);
+            return TryCreate(DateTime.UtcNow, serverId, destination);
         }
 
         /// <summary>
@@ -38,32 +37,21 @@ namespace AuthorizedBuyersHelpers {
         /// <param name="date">初期化ベクトルの前段 8 bytes に書き込む日時。うち、上位 4 bytes が秒、下位 4 bytes がマイクロ秒を表す。バイトオーダーは BigEndian。</param>
         /// <param name="serverId">初期化ベクトルの後段 8 bytes に書き込むサーバー ID。バイトオーダーは BigEndian。</param>
         /// <param name="destination">初期化ベクトルの書き込み先となる <see cref="byte"/> のスパン。</param>
-        /// <param name="bytesWritten">
-        /// 実際に <paramref name="destination"/> に書き込まれたバイトサイズ。
-        /// 成功した場合は常に <see cref="ABCrypto.IVSize"/> になります。
-        /// </param>
         /// <returns>
         /// 生成に成功した場合は <c>true</c>。
         /// <paramref name="destination"/> の長さが <see cref="ABCrypto.IVSize"/> に満たない場合、
         /// または <paramref name="date"/> が <see cref="UnixTime.Epoch"/> より古い日時の場合、<c>false</c> となります。
         /// </returns>
-        public static bool TryCreate(DateTime date, long serverId, Span<byte> destination, out int bytesWritten) {
-            if (destination.Length < ABCrypto.IVSize) {
-                bytesWritten = 0;
-                return false;
-            }
+        public static bool TryCreate(DateTime date, long serverId, Span<byte> destination) {
+            if (destination.Length < ABCrypto.IVSize) { return false; }
 
             var microUnixtime = new UnixTime(date).TimeSpan.Ticks / 10;
-            if (microUnixtime < 0) {
-                bytesWritten = 0;
-                return false;
-            }
+            if (microUnixtime < 0) { return false; }
 
             BinaryPrimitives.WriteUInt32BigEndian(destination.Slice(0, 4), (uint)(microUnixtime / 1_000_000));
             BinaryPrimitives.WriteUInt32BigEndian(destination.Slice(4, 4), (uint)(microUnixtime % 1_000_000));
             BinaryPrimitives.WriteInt64BigEndian(destination.Slice(8, 8), serverId);
 
-            bytesWritten = ABCrypto.IVSize;
             return true;
         }
     }

--- a/src/AuthorizedBuyersHelpers/ABPriceCrypto.cs
+++ b/src/AuthorizedBuyersHelpers/ABPriceCrypto.cs
@@ -77,31 +77,31 @@ namespace AuthorizedBuyersHelpers {
         /// 暗号化に使用される初期化ベクトル。
         /// 長さが <see cref="ABCrypto.IVSize"/> に満たない場合は不足分を 0 で埋め、<see cref="ABCrypto.IVSize"/> を超える場合は <see cref="ABCrypto.IVSize"/> まで切り詰めて使用します。
         /// </param>
-        /// <param name="cipherBytes">
+        /// <param name="destination">
         /// 暗号データの書き込み先となる <see cref="byte"/> スパン。
         /// 少なくとも <see cref="CipherSize"/> 以上の長さが必要です。
         /// </param>
         /// <param name="bytesWritten">
-        /// 実際に <paramref name="cipherBytes"/> に書き込まれたバイトサイズ。
+        /// 実際に <paramref name="destination"/> に書き込まれたバイトサイズ。
         /// 暗号化に成功した場合は <see cref="CipherSize"/> の値になります。
         /// </param>
         /// <returns>
         /// 暗号化に成功した場合は <c>true</c>。
-        /// <paramref name="cipherBytes"/> の長さが <see cref="CipherSize"/> を満たしていない場合は <c>false</c>。
+        /// <paramref name="destination"/> の長さが <see cref="CipherSize"/> を満たしていない場合は <c>false</c>。
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="crypto"/> is <c>null</c>.</exception>
         /// <exception cref="OverflowException">
         /// <paramref name="price"/> が <c><see cref="long.MaxValue"/> / 1_000_000</c> より大きい、
         /// または <c><see cref="long.MinValue"/> / 1_000_000 より小さい。</c>
         /// </exception>
-        public static bool TryEncryptPrice(this ABCrypto crypto, decimal price, ReadOnlySpan<byte> inputIV, Span<byte> cipherBytes, out int bytesWritten) {
+        public static bool TryEncryptPrice(this ABCrypto crypto, decimal price, ReadOnlySpan<byte> inputIV, Span<byte> destination, out int bytesWritten) {
             if (crypto == null) { throw new ArgumentNullException(nameof(crypto)); }
-            if (cipherBytes.Length < CipherSize) { goto Failure; }
+            if (destination.Length < CipherSize) { goto Failure; }
 
             Span<byte> microPriceData = stackalloc byte[PricePayloadSize];
             BinaryPrimitives.WriteInt64BigEndian(microPriceData, (long)(price * MicrosPerCurrencyUnit));
 
-            var success = crypto.TryEncrypt(microPriceData, inputIV, cipherBytes, out bytesWritten);
+            var success = crypto.TryEncrypt(microPriceData, inputIV, destination, out bytesWritten);
             Debug.Assert(success);
             Debug.Assert(bytesWritten == CipherSize);
             return true;

--- a/src/AuthorizedBuyersHelpers/ABPriceCrypto.cs
+++ b/src/AuthorizedBuyersHelpers/ABPriceCrypto.cs
@@ -32,7 +32,7 @@ namespace AuthorizedBuyersHelpers {
             if (crypto == null) { throw new ArgumentNullException(nameof(crypto)); }
 
             Span<byte> iv = stackalloc byte[ABCrypto.IVSize];
-            var success = ABIV.TryCreate(iv, out _);
+            var success = ABIV.TryCreate(iv);
             Debug.Assert(success);
 
             return EncryptPrice(crypto, price, iv);

--- a/src/AuthorizedBuyersHelpers/AuthorizedBuyersHelpers.csproj
+++ b/src/AuthorizedBuyersHelpers/AuthorizedBuyersHelpers.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/in-async/AuthorizedBuyersHelpers</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/in-async/AuthorizedBuyersHelpers/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>library rtb</PackageTags>
-    <Version>1.1.0-alpha.1</Version>
+    <Version>2.0.0-alpha.1</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/AuthorizedBuyersHelpers/IABCryptoKeys.cs
+++ b/src/AuthorizedBuyersHelpers/IABCryptoKeys.cs
@@ -1,4 +1,6 @@
-﻿namespace AuthorizedBuyersHelpers {
+﻿using System;
+
+namespace AuthorizedBuyersHelpers {
 
     /// <summary>
     /// Authorized Buyers の暗号化スキームに必要なキーセット。
@@ -18,5 +20,36 @@
         /// 整合性キー。常に非 <c>null</c>。
         /// </summary>
         byte[] IntegrityKey { get; }
+    }
+
+    /// <summary>
+    /// <see cref="IABCryptoKeys"/> の実装クラス。
+    /// </summary>
+    public class ABCryptoKeys : IABCryptoKeys {
+
+        /// <summary>
+        /// <see cref="ABCryptoKeys"/> クラスの新しいインスタンスを初期化します。
+        /// </summary>
+        /// <param name="encryptionKey"><see cref="EncryptionKey"/> に渡される値。</param>
+        /// <param name="integrityKey"><see cref="IntegrityKey"/> に渡される値。</param>
+        /// <exception cref="ArgumentNullException"><paramref name="encryptionKey"/> or <paramref name="integrityKey"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="encryptionKey"/> or <paramref name="integrityKey"/> is empty.</exception>
+        public ABCryptoKeys(byte[] encryptionKey, byte[] integrityKey) {
+            EncryptionKey = encryptionKey ?? throw new ArgumentNullException(nameof(encryptionKey));
+            if (encryptionKey.Length == 0) { throw new ArgumentException($"{nameof(EncryptionKey)} is empty.", nameof(encryptionKey)); }
+
+            IntegrityKey = integrityKey ?? throw new ArgumentNullException(nameof(integrityKey));
+            if (integrityKey.Length == 0) { throw new ArgumentException($"{nameof(IntegrityKey)} is empty.", nameof(integrityKey)); }
+        }
+
+        /// <summary>
+        /// <see cref="IABCryptoKeys.EncryptionKey"/> の実装。
+        /// </summary>
+        public byte[] EncryptionKey { get; }
+
+        /// <summary>
+        /// <see cref="IABCryptoKeys.IntegrityKey"/> の実装。
+        /// </summary>
+        public byte[] IntegrityKey { get; }
     }
 }

--- a/tests/AuthorizedBuyersHelpers.Tests/ABCryptoKeysTests.cs
+++ b/tests/AuthorizedBuyersHelpers.Tests/ABCryptoKeysTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Inasync;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AuthorizedBuyersHelpers.Tests {
+
+    [TestClass]
+    public class ABCryptoKeysTests {
+
+        [TestMethod]
+        public void Ctor() {
+            Action TestCase(int testNumber, byte[] eKey, byte[] iKey, Type expectedExceptionType = null) => () => {
+                new TestCaseRunner($"No.{testNumber}")
+                    .Run(() => new ABCryptoKeys(eKey, iKey))
+                    .Verify((actual, desc) => {
+                        actual.EncryptionKey.Is(eKey, desc);
+                        actual.IntegrityKey.Is(iKey, desc);
+                    }, expectedExceptionType);
+            };
+
+            new[] {
+                TestCase( 0, null                    , Rand.Bytes(minLength: 1), typeof(ArgumentNullException)),
+                TestCase( 1, new byte[0]             , Rand.Bytes(minLength: 1), typeof(ArgumentException)),
+                TestCase( 2, Rand.Bytes(minLength: 1), null                    , typeof(ArgumentNullException)),
+                TestCase( 3, Rand.Bytes(minLength: 1), new byte[0]             , typeof(ArgumentException)),
+                TestCase(10, Rand.Bytes(minLength: 1), Rand.Bytes(minLength: 1)),
+            }.Run();
+        }
+    }
+}

--- a/tests/AuthorizedBuyersHelpers.Tests/ABIVTests.cs
+++ b/tests/AuthorizedBuyersHelpers.Tests/ABIVTests.cs
@@ -11,33 +11,29 @@ namespace AuthorizedBuyersHelpers.Tests {
 
         [TestMethod]
         public void TryCreate_Auto() {
-            Action TestCase(int testNumber, byte[] destination, (bool success, int bytesWritten) expected, Type expectedExceptionType = null) => () => {
+            Action TestCase(int testNumber, byte[] destination, bool expected, Type expectedExceptionType = null) => () => {
                 new TestCaseRunner($"No.{testNumber}")
-                    .Run(() => (success: ABIV.TryCreate(destination, out var bytesWritten), bytesWritten))
-                    .Verify((actual, desc) => {
-                        actual.success.Is(expected.success, desc);
-                        actual.bytesWritten.Is(expected.bytesWritten, desc);
-                    }, expectedExceptionType);
+                    .Run(() => ABIV.TryCreate(destination))
+                    .Verify(expected, expectedExceptionType);
             };
 
             new[]{
-                TestCase( 0, new byte[0] , (false, 0)),
-                TestCase( 1, new byte[15], (false, 0)),
-                TestCase( 2, new byte[16], (true , 16)),
-                TestCase( 3, new byte[17], (true , 16)),
+                TestCase( 0, new byte[0] , false),
+                TestCase( 1, new byte[15], false),
+                TestCase( 2, new byte[16], true ),
+                TestCase( 3, new byte[17], true ),
             }.Run();
         }
 
         [TestMethod]
         public void TryCreate() {
-            Action TestCase(int testNumber, DateTime date, long serverId, byte[] destination, (bool success, int bytesWritten, uint seconds, uint micros) expected, Type expectedExceptionType = null) => () => {
+            Action TestCase(int testNumber, DateTime date, long serverId, byte[] destination, (bool success, uint seconds, uint micros) expected, Type expectedExceptionType = null) => () => {
                 new TestCaseRunner($"No.{testNumber}")
-                    .Run(() => (success: ABIV.TryCreate(date, serverId, destination, out var bytesWritten), bytesWritten))
+                    .Run(() => ABIV.TryCreate(date, serverId, destination))
                     .Verify((actual, desc) => {
-                        actual.success.Is(expected.success, desc);
-                        actual.bytesWritten.Is(expected.bytesWritten, desc);
+                        actual.Is(expected.success, desc);
 
-                        if (actual.success) {
+                        if (actual) {
                             BinaryPrimitives.ReadUInt32BigEndian(destination.AsSpan(0, 4)).Is(expected.seconds, desc);
                             BinaryPrimitives.ReadUInt32BigEndian(destination.AsSpan(4, 4)).Is(expected.micros, desc);
                             BinaryPrimitives.ReadInt64BigEndian(destination.AsSpan(8, 8)).Is(serverId, desc);
@@ -47,15 +43,15 @@ namespace AuthorizedBuyersHelpers.Tests {
 
             var now = DateTime.Parse("2019-06-17T07:33:12.2270981Z", null, DateTimeStyles.AdjustToUniversal);
             new[]{
-                TestCase( 0, now, (long)(Rand.Next() * long.MaxValue), new byte[0] , (false, 0 , default, default)),
-                TestCase( 1, now, (long)(Rand.Next() * long.MaxValue), new byte[15], (false, 0 , default, default)),
-                TestCase( 2, now, (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 16, 1560756792, 227098)),
-                TestCase( 3, now, (long)(Rand.Next() * long.MaxValue), new byte[17], (true , 16, 1560756792, 227098)),
-                TestCase(10, new DateTime(1969, 12, 31, 23, 59, 59, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (false, 0, default, default)),  // UNIX Epoch より古い日時。
-                TestCase(11, new DateTime(1970,  1,  1,  0,  0,  0, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 16, 0, 0)),  // UNIX Epoch。
-                TestCase(12, new DateTime(1970,  1,  1,  0,  0,  1, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 16, 1, 0)),  // UNIX Epoch + 1s。
-                TestCase(13, new DateTime(2038,  1, 19,  3, 14,  8, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 16, (uint)int.MaxValue + 1, 0)),  // 2038 年問題。
-                TestCase(14, new DateTime(2106,  2,  7,  6, 28, 16, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 16, 0, 0)),  // 2106 年問題。
+                TestCase( 0, now, (long)(Rand.Next() * long.MaxValue), new byte[0] , (false, default, default)),
+                TestCase( 1, now, (long)(Rand.Next() * long.MaxValue), new byte[15], (false, default, default)),
+                TestCase( 2, now, (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 1560756792, 227098)),
+                TestCase( 3, now, (long)(Rand.Next() * long.MaxValue), new byte[17], (true , 1560756792, 227098)),
+                TestCase(10, new DateTime(1969, 12, 31, 23, 59, 59, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (false, default, default)),  // UNIX Epoch より古い日時。
+                TestCase(11, new DateTime(1970,  1,  1,  0,  0,  0, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 0, 0)),  // UNIX Epoch。
+                TestCase(12, new DateTime(1970,  1,  1,  0,  0,  1, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 1, 0)),  // UNIX Epoch + 1s。
+                TestCase(13, new DateTime(2038,  1, 19,  3, 14,  8, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (true , (uint)int.MaxValue + 1, 0)),  // 2038 年問題。
+                TestCase(14, new DateTime(2106,  2,  7,  6, 28, 16, DateTimeKind.Utc), (long)(Rand.Next() * long.MaxValue), new byte[16], (true , 0, 0)),  // 2106 年問題。
             }.Run();
         }
 
@@ -70,7 +66,7 @@ namespace AuthorizedBuyersHelpers.Tests {
 
             var destination = new byte[ABCrypto.IVSize];
             new TestCaseRunner()
-                .Run(() => ABIV.TryCreate(timestamp, serverId, destination, out _))
+                .Run(() => ABIV.TryCreate(timestamp, serverId, destination))
                 .Verify((actual, _) => {
                     actual.Is(true);
                     destination.Is(Base16.Decode("386E3AC0000C0A080123456789ABCDEF"));

--- a/tests/AuthorizedBuyersHelpers.Tests/ABPriceCryptoTests.cs
+++ b/tests/AuthorizedBuyersHelpers.Tests/ABPriceCryptoTests.cs
@@ -66,12 +66,11 @@ namespace AuthorizedBuyersHelpers.Tests {
 
         [TestMethod]
         public void TryEncryptPrice_ReadOnlySpan() {
-            Action TestCase(int testNumber, ABCrypto crypto, decimal price, byte[] inputIV, byte[] cipherBytes, (bool success, int bytesWritten, byte[] cipherBytes) expected, Type expectedExceptionType = null) => () => {
+            Action TestCase(int testNumber, ABCrypto crypto, decimal price, byte[] inputIV, byte[] cipherBytes, (bool success, byte[] cipherBytes) expected, Type expectedExceptionType = null) => () => {
                 new TestCaseRunner($"No.{testNumber}")
-                    .Run(() => (success: ABPriceCrypto.TryEncryptPrice(crypto, price, inputIV, cipherBytes, out var bytesWritten), cipherBytes, bytesWritten))
+                    .Run(() => (success: ABPriceCrypto.TryEncryptPrice(crypto, price, inputIV, cipherBytes), cipherBytes))
                     .Verify((actual, desc) => {
                         actual.success.Is(expected.success, desc);
-                        actual.bytesWritten.Is(expected.bytesWritten, desc);
                         actual.cipherBytes.Is(expected.cipherBytes, desc);
                     }, expectedExceptionType);
             };
@@ -81,17 +80,17 @@ namespace AuthorizedBuyersHelpers.Tests {
             var longIV = Base16.Decode("386E3AC0000C0A080123456789ABCDEF01");
             new[] {
                 TestCase( 0, null   , 0m     , iv     , new byte[28], default, typeof(ArgumentNullException)),
-                TestCase( 1, _crypto, 0m     , iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTOrlB8A3F8A=="))),
-                TestCase( 2, _crypto, -1.2m  , iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7xZyNLqs1wnBKd_m9w=="))),
-                TestCase( 3, _crypto, 0.123m , iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTO1k5XIpbSg=="))),
-                TestCase( 4, _crypto, 1.2m   , iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTKPbB3o5CMQ=="))),
-                TestCase( 5, _crypto, 123.45m, iv     , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VUYQvRuIJiRw=="))),
-                TestCase( 6, _crypto, 123.45m, shortIV, new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavNAF7WOkwZcM1moYKxlA=="))),
-                TestCase( 7, _crypto, 123.45m, longIV , new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VUYQvRuIJiRw=="))),
-                TestCase( 8, _crypto, 1.2m   , iv     , new byte[27], (false, 0, new byte[27])),
-                TestCase(10, _crypto, (decimal)long.MinValue / 1_000_000            , iv, new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN72mNy0VTOrlBMgsdYg=="))),
+                TestCase( 1, _crypto, 0m     , iv     , new byte[28], (true , Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTOrlB8A3F8A=="))),
+                TestCase( 2, _crypto, -1.2m  , iv     , new byte[28], (true , Base64Url.Decode("OG46wAAMCggBI0VniavN7xZyNLqs1wnBKd_m9w=="))),
+                TestCase( 3, _crypto, 0.123m , iv     , new byte[28], (true , Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTO1k5XIpbSg=="))),
+                TestCase( 4, _crypto, 1.2m   , iv     , new byte[28], (true , Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VTKPbB3o5CMQ=="))),
+                TestCase( 5, _crypto, 123.45m, iv     , new byte[28], (true , Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VUYQvRuIJiRw=="))),
+                TestCase( 6, _crypto, 123.45m, shortIV, new byte[28], (true , Base64Url.Decode("OG46wAAMCggBI0VniavNAF7WOkwZcM1moYKxlA=="))),
+                TestCase( 7, _crypto, 123.45m, longIV , new byte[28], (true , Base64Url.Decode("OG46wAAMCggBI0VniavN7-mNy0VUYQvRuIJiRw=="))),
+                TestCase( 8, _crypto, 1.2m   , iv     , new byte[27], (false, new byte[27])),
+                TestCase(10, _crypto, (decimal)long.MinValue / 1_000_000            , iv, new byte[28], (true, Base64Url.Decode("OG46wAAMCggBI0VniavN72mNy0VTOrlBMgsdYg=="))),
                 TestCase(11, _crypto, (decimal)long.MinValue / 1_000_000 - 0.000001m, iv, new byte[28], default, typeof(OverflowException)),
-                TestCase(12, _crypto, (decimal)long.MaxValue / 1_000_000            , iv, new byte[28], (true, 28, Base64Url.Decode("OG46wAAMCggBI0VniavN75ZyNLqsxUa-p2RaNA=="))),
+                TestCase(12, _crypto, (decimal)long.MaxValue / 1_000_000            , iv, new byte[28], (true, Base64Url.Decode("OG46wAAMCggBI0VniavN75ZyNLqsxUa-p2RaNA=="))),
                 TestCase(13, _crypto, (decimal)long.MaxValue / 1_000_000 + 1        , iv, new byte[28], default, typeof(OverflowException)),
             }.Run();
         }


### PR DESCRIPTION
## 概要
v1.1.0-alpha.1 で公開 API の in パラメーターを削除するという破壊的変更を加えてしまった。
もう折角なので他の API もブラッシュアップし、v2 とする事にした。

Changes:
- 処理の書き込み先となる Span<byte> のパラメーター名を destination に統一。
- ABPriceCrypto.TryEncryptPrice() の書き込みバイト数は常に CipherSize なので、bytesWritten out パラメーターをオミット。
- ABIV.TryCreate() の書き込みバイト数は常に ABCrypto.IVSize なので、bytesWritten out パラメーターをオミット。
- IABCryptoKeys の参照実装クラス ABCryptoKeys を追加。
